### PR TITLE
Add support for PSR6 cache to API client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     "namshi/jose": "^6.0 || ^7.0",
     "jms/serializer": "^1.0",
     "guzzlehttp/guzzle": "^5.0 || ^6.0",
-    "movingimage/video-manager-meta": "^1.2"
+    "movingimage/video-manager-meta": "^1.2",
+    "psr/cache": "^1.0",
+    "cache/void-adapter": "^1.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^1.12",

--- a/lib/ApiClient/AbstractApiClient.php
+++ b/lib/ApiClient/AbstractApiClient.php
@@ -179,12 +179,18 @@ abstract class AbstractApiClient extends AbstractCoreApiClient implements ApiCli
      */
     public function getEmbedCode($videoManagerId, $videoId, $playerDefinitionId, $embedType = 'html')
     {
-        $response = $this->makeRequest('GET',
-            sprintf('videos/%s/embed-codes?player_definition_id=%s&embed_type=%s',
-                $videoId, $playerDefinitionId, $embedType), [
-                self::OPT_VIDEO_MANAGER_ID => $videoManagerId,
-            ]
+        $url = sprintf(
+            'videos/%s/embed-codes?player_definition_id=%s&embed_type=%s',
+            $videoId,
+            $playerDefinitionId,
+            $embedType
         );
+
+        if ($this->cacheTtl) {
+            $url = sprintf('%s&token_lifetime_in_seconds=%s', $url, $this->cacheTtl);
+        }
+
+        $response = $this->makeRequest('GET', $url, [self::OPT_VIDEO_MANAGER_ID => $videoManagerId]);
 
         $data = \json_decode($response->getBody(), true);
         $embedCode = new EmbedCode();

--- a/lib/ApiClient/AbstractCoreApiClient.php
+++ b/lib/ApiClient/AbstractCoreApiClient.php
@@ -2,10 +2,12 @@
 
 namespace MovingImage\Client\VMPro\ApiClient;
 
+use Cache\Adapter\Void\VoidCachePool;
 use GuzzleHttp\ClientInterface;
 use JMS\Serializer\Serializer;
 use MovingImage\Client\VMPro\Exception;
 use MovingImage\Client\VMPro\Util\Logging\Traits\LoggerAwareTrait;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 
@@ -34,17 +36,36 @@ abstract class AbstractCoreApiClient implements LoggerAwareInterface
     protected $serializer;
 
     /**
+     * @var CacheItemPoolInterface PSR6 cache pool implementation
+     */
+    protected $cacheItemPool;
+
+    /**
+     * @var mixed time-to-live for cached responses
+     *            The type of this property might be integer, \DateInterval or null
+     *
+     * @see CacheItemInterface::expiresAfter()
+     */
+    protected $cacheTtl;
+
+    /**
      * ApiClient constructor.
      *
-     * @param ClientInterface $httpClient
-     * @param Serializer      $serializer
+     * @param ClientInterface        $httpClient
+     * @param Serializer             $serializer
+     * @param CacheItemPoolInterface $cacheItemPool
+     * @param int                    $cacheTtl
      */
     public function __construct(
         ClientInterface $httpClient,
-        Serializer $serializer
+        Serializer $serializer,
+        CacheItemPoolInterface $cacheItemPool = null,
+        $cacheTtl = null
     ) {
         $this->httpClient = $httpClient;
         $this->serializer = $serializer;
+        $this->cacheItemPool = $cacheItemPool ?: new VoidCachePool();
+        $this->cacheTtl = $cacheTtl;
     }
 
     /**
@@ -79,10 +100,24 @@ abstract class AbstractCoreApiClient implements LoggerAwareInterface
                 $uri = sprintf('%d/%s', $options[self::OPT_VIDEO_MANAGER_ID], $uri);
             }
 
+            $cacheKey = $this->generateCacheKey($method, $uri, $options);
+            $cacheItem = $this->cacheItemPool->getItem($cacheKey);
+            if ($cacheItem->isHit()) {
+                $logger->info(sprintf('Getting response from cache for %s request to %s', $method, $uri), [$uri]);
+
+                return $this->unserializeResponse($cacheItem->get());
+            }
+
             $logger->info(sprintf('Making API %s request to %s', $method, $uri), [$uri]);
 
             /** @var ResponseInterface $response */
             $response = $this->_doRequest($method, $uri, $options);
+
+            if ($this->isCachable($method, $uri, $options, $response)) {
+                $cacheItem->set($this->serializeResponse($response));
+                $cacheItem->expiresAfter($this->cacheTtl);
+                $this->cacheItemPool->save($cacheItem);
+            }
 
             $logger->debug('Response from HTTP call was status code:', [$response->getStatusCode()]);
             $logger->debug('Response JSON was:', [$response->getBody()]);
@@ -145,4 +180,58 @@ abstract class AbstractCoreApiClient implements LoggerAwareInterface
 
         return $json;
     }
+
+    /**
+     * Generates the cache key based on the class name, request method, uri and options.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $options
+     *
+     * @return string
+     */
+    private function generateCacheKey($method, $uri, array $options = [])
+    {
+        return sha1(sprintf('%s.%s.%s.%s', get_class($this), $method, $uri, json_encode($options)));
+    }
+
+    /**
+     * Checks if the request may be cached.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $options
+     * @param mixed  $response
+     *
+     * @return bool
+     */
+    private function isCachable($method, $uri, array $options, $response)
+    {
+        /** @var ResponseInterface $statusCode */
+        $statusCode = $response->getStatusCode();
+
+        return $method === 'GET' && $statusCode >= 200 && $statusCode < 300;
+    }
+
+    /**
+     * Serializes the provided response to a string, suitable for caching.
+     * The type of the $response argument varies depending on the guzzle version.
+     *
+     * @param mixed $response
+     *
+     * @return string
+     */
+    abstract protected function serializeResponse($response);
+
+    /**
+     * Unserializes the serialized response into a response object.
+     * The return type varies depending on the guzzle version.
+     *
+     * @param string $serialized
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     */
+    abstract protected function unserializeResponse($serialized);
 }

--- a/lib/Factory/AbstractApiClientFactory.php
+++ b/lib/Factory/AbstractApiClientFactory.php
@@ -10,6 +10,7 @@ use MovingImage\Client\VMPro\Entity\ApiCredentials;
 use MovingImage\Client\VMPro\Extractor\TokenExtractor;
 use MovingImage\Client\VMPro\Interfaces\ApiClientFactoryInterface;
 use MovingImage\Client\VMPro\Manager\TokenManager;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractApiClientFactory implements ApiClientFactoryInterface
@@ -58,10 +59,12 @@ abstract class AbstractApiClientFactory implements ApiClientFactoryInterface
     public function create(
         ClientInterface $httpClient,
         Serializer $serializer,
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
+        CacheItemPoolInterface $cacheItemPool = null,
+        $cacheTtl = null
     ) {
         $cls = $this->getApiClientClass();
-        $apiClient = new $cls($httpClient, $serializer);
+        $apiClient = new $cls($httpClient, $serializer, $cacheItemPool, $cacheTtl);
 
         if (!is_null($logger)) {
             $apiClient->setLogger($logger);

--- a/lib/Interfaces/ApiClientFactoryInterface.php
+++ b/lib/Interfaces/ApiClientFactoryInterface.php
@@ -6,6 +6,7 @@ use GuzzleHttp\ClientInterface;
 use JMS\Serializer\Serializer;
 use MovingImage\Client\VMPro\Entity\ApiCredentials;
 use MovingImage\Client\VMPro\Manager\TokenManager;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -38,16 +39,20 @@ interface ApiClientFactoryInterface
      * Factory method to create a new instance of the VMPro
      * API Client.
      *
-     * @param ClientInterface      $httpClient
-     * @param Serializer           $serializer
-     * @param LoggerInterface|null $logger
+     * @param ClientInterface        $httpClient
+     * @param Serializer             $serializer
+     * @param LoggerInterface|null   $logger
+     * @param CacheItemPoolInterface $cacheItemPool
+     * @param mixed                  $cacheTtl
      *
      * @return ApiClientInterface
      */
     public function create(
         ClientInterface $httpClient,
         Serializer $serializer,
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
+        CacheItemPoolInterface $cacheItemPool = null,
+        $cacheTtl = null
     );
 
     /**

--- a/tests/MovingImage/Test/Client/VMPro/ApiClient/AbstractApiClientImpl.php
+++ b/tests/MovingImage/Test/Client/VMPro/ApiClient/AbstractApiClientImpl.php
@@ -3,6 +3,7 @@
 namespace MovingImage\Test\Client\VMPro\ApiClient;
 
 use MovingImage\Client\VMPro\ApiClient\AbstractApiClient;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class AbstractApiClientImpl.
@@ -12,14 +13,22 @@ use MovingImage\Client\VMPro\ApiClient\AbstractApiClient;
 class AbstractApiClientImpl extends AbstractApiClient
 {
     /**
-     * Actually do nothing here.
+     * @var mixed
+     */
+    private $response;
+
+    /**
+     * Returns the response provided in setResponse method - or null.
      *
      * @param string $method
      * @param string $uri
      * @param array  $options
+     *
+     * @return ResponseInterface|null
      */
     public function _doRequest($method, $uri, $options)
     {
+        return $this->response;
     }
 
     /**
@@ -43,5 +52,43 @@ class AbstractApiClientImpl extends AbstractApiClient
     public function buildJsonParameters(array $required, array $optional)
     {
         return parent::buildJsonParameters($required, $optional);
+    }
+
+    /**
+     * Type of the $response object depends on the guzzle version.
+     *
+     * @param mixed $response
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * No-op implementation - returns whatever was passed as an argument.
+     *
+     * {@inheritdoc}
+     *
+     * @param mixed $response
+     *
+     * @return mixed
+     */
+    protected function serializeResponse($response)
+    {
+        return $response;
+    }
+
+    /**
+     * No-op implementation - returns whatever was passed as an argument.
+     *
+     * {@inheritdoc}
+     *
+     * @param mixed $serialized
+     *
+     * @return mixed
+     */
+    protected function unserializeResponse($serialized)
+    {
+        return $serialized;
     }
 }


### PR DESCRIPTION
Adds support for PSR6 cache implementations to API client. By default, uses a no-op cache implementation provided by the cache/void-adapter. If a PSR6 cache implementation is provided in the constructor (TTL can also be optionally supplied here), the client will start caching all responses to the provided cache implementation.