### PR TITLE
Add getter/setter for CacheItemPoolInterface implementation to API client

### DIFF
--- a/lib/ApiClient/AbstractCoreApiClient.php
+++ b/lib/ApiClient/AbstractCoreApiClient.php
@@ -69,6 +69,22 @@ abstract class AbstractCoreApiClient implements LoggerAwareInterface
     }
 
     /**
+     * @param CacheItemPoolInterface $cacheItemPool
+     */
+    public function setCacheItemPool(CacheItemPoolInterface $cacheItemPool)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+    }
+
+    /**
+     * @return CacheItemPoolInterface
+     */
+    public function getCacheItemPool()
+    {
+        return $this->cacheItemPool;
+    }
+
+    /**
      * Perform the actual request in the implementation classes.
      *
      * @param string $method

--- a/lib/ApiClient/Guzzle6ApiClient.php
+++ b/lib/ApiClient/Guzzle6ApiClient.php
@@ -5,6 +5,7 @@ namespace MovingImage\Client\VMPro\ApiClient;
 use MovingImage\Client\VMPro\Interfaces\ApiClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Psr7\Response;
+use MovingImage\Client\VMPro\Exception;
 
 /**
  * Class Guzzle6ApiClient.


### PR DESCRIPTION
Adds getter and setter methods for CacheItemPoolInterface implementation to API client, so that cache pool implementation can be modified dynamically. 