### PR TITLE
Attachments - update min version for meta class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "namshi/jose": "^6.0 || ^7.0",
     "jms/serializer": "^1.0",
     "guzzlehttp/guzzle": "^5.0 || ^6.0",
-    "movingimage/video-manager-meta": "^1.2",
+    "movingimage/video-manager-meta": "^1.3",
     "psr/cache": "^1.0",
     "cache/void-adapter": "^1.0"
   },


### PR DESCRIPTION
Change version for meta library to 1.3 because now it is necessary to use from 1.3