### PR TITLE
Add support for video ID in VideosRequestParameters

### DIFF
--- a/lib/Entity/VideosRequestParameters.php
+++ b/lib/Entity/VideosRequestParameters.php
@@ -7,6 +7,8 @@ use MovingImage\Client\VMPro\Util\AccessorTrait;
 /**
  * Class VideosRequestParameters.
  *
+ * @method int getVideoId()
+ * @method VideosRequestParameters setVideoId(int $videoId)
  * @method int getChannelId()
  * @method VideosRequestParameters setChannelId(int $channelId)
  * @method int getOffset()

--- a/lib/Util/SearchEndpointTrait.php
+++ b/lib/Util/SearchEndpointTrait.php
@@ -150,6 +150,7 @@ trait SearchEndpointTrait
             $queryParams = [
                 'channels' => $parameters->getChannelId(),
                 'published' => $parameters->getPublicationState(),
+                'id' => $parameters->getVideoId(),
                 $parameters->getSearchInField() => $parameters->getSearchTerm(),
             ];
 

--- a/tests/MovingImage/Test/Util/SearchEndpointTraitTest.php
+++ b/tests/MovingImage/Test/Util/SearchEndpointTraitTest.php
@@ -206,6 +206,7 @@ class SearchEndpointTraitTest extends \PHPUnit_Framework_TestCase
         return [
             [[]],
             [['channelId' => 100]],
+            [['id' => 'Aqu1xrUtsBAmDWdr_J2bBU']],
             [['order' => 'desc', 'orderProperty' => 'name']],
             [['limit' => 10, 'offset' => 20]],
             [['publicationState' => false]],


### PR DESCRIPTION
In order to support fetching a single video using the search endpoint, we need to add support for specifying the video ID in VideosRequestParameters object.