### PR TITLE
Support for metadataSetKey when searching for videos

### DIFF
--- a/lib/Entity/VideosRequestParameters.php
+++ b/lib/Entity/VideosRequestParameters.php
@@ -33,6 +33,8 @@ use MovingImage\Meta\Enums\PublicationState;
  * @method VideosRequestParameters setIncludeChannelAssignments(bool $includeChannels)
  * @method bool isIncludeSubChannels()
  * @method VideosRequestParameters setIncludeSubChannels(bool $includeSubChannels)
+ * @method VideosRequestParameters setMetadataSetKey(string $metadataSetKey)
+ * @method string getMetadataSetKey()
  *
  * @author Omid Rad <omid.rad@movingimage.com>
  */

--- a/lib/Util/SearchEndpointTrait.php
+++ b/lib/Util/SearchEndpointTrait.php
@@ -134,18 +134,6 @@ trait SearchEndpointTrait
         $options = [
             'documentType' => 'video',
             'videoManagerIds' => [$videoManagerId],
-            'fetchSources' => [
-                'id',
-                'title',
-                'description',
-                'createdDate',
-                'duration',
-                'published',
-                'customMetadata',
-                'keywords',
-                'channels',
-                'downloadable',
-            ],
         ];
 
         if ($parameters) {
@@ -172,6 +160,10 @@ trait SearchEndpointTrait
                 'order' => $parameters->getOrder(),
                 'query' => $this->createElasticSearchQuery($queryParams),
             ];
+
+            if ($parameters->getMetadataSetKey()) {
+                $options['metaDataSetKey'] = $parameters->getMetadataSetKey();
+            }
         }
 
         return $options;
@@ -190,14 +182,6 @@ trait SearchEndpointTrait
         $options = [
             'documentType' => 'channel',
             'videoManagerIds' => [$videoManagerId],
-            'fetchSources' => [
-                'id',
-                'videoManagerId',
-                'parentId',
-                'name',
-                'description',
-                'customMetadata',
-            ],
         ];
 
         $queryParams = [

--- a/tests/MovingImage/Test/Util/SearchEndpointTraitTest.php
+++ b/tests/MovingImage/Test/Util/SearchEndpointTraitTest.php
@@ -137,18 +137,6 @@ class SearchEndpointTraitTest extends \PHPUnit_Framework_TestCase
     {
         $params = $this->createVideosRequestParameters($params);
         $vmId = 42;
-        $expectedFetchSources = [
-            'id',
-            'title',
-            'description',
-            'createdDate',
-            'duration',
-            'published',
-            'customMetadata',
-            'keywords',
-            'channels',
-            'downloadable',
-        ];
 
         $options = $this->traitObj->getRequestOptionsForSearchVideosEndpoint($vmId, $params);
 
@@ -156,8 +144,6 @@ class SearchEndpointTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('video', $options['documentType']);
         $this->assertArrayHasKey('videoManagerIds', $options);
         $this->assertSame([$vmId], $options['videoManagerIds']);
-        $this->assertArrayHasKey('fetchSources', $options);
-        $this->assertSame($expectedFetchSources, $options['fetchSources']);
 
         if ($params->getLimit()) {
             $this->assertArrayHasKey('size', $options);
@@ -232,14 +218,6 @@ class SearchEndpointTraitTest extends \PHPUnit_Framework_TestCase
     {
         $params = $this->createChannelsRequestParameters($params);
         $vmId = 42;
-        $expectedFetchSources = [
-            'id',
-            'videoManagerId',
-            'parentId',
-            'name',
-            'description',
-            'customMetadata',
-        ];
 
         $options = $this->traitObj->getRequestOptionsForSearchChannelsEndpoint($vmId, $params);
 
@@ -247,8 +225,6 @@ class SearchEndpointTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('channel', $options['documentType']);
         $this->assertArrayHasKey('videoManagerIds', $options);
         $this->assertSame([$vmId], $options['videoManagerIds']);
-        $this->assertArrayHasKey('fetchSources', $options);
-        $this->assertSame($expectedFetchSources, $options['fetchSources']);
 
         if ($params->getLimit()) {
             $this->assertArrayHasKey('size', $options);


### PR DESCRIPTION
- Adds support for searching videos by metaDataSetKey (ie language)
- Removes `fetchSources` from the request, because the metadata implementation is currently not yet stable and it's safer to rely on the default set of response properties.