### PR TITLE
Add support for arrays in query string

### DIFF
--- a/lib/ApiClient/AbstractApiClient.php
+++ b/lib/ApiClient/AbstractApiClient.php
@@ -109,7 +109,8 @@ abstract class AbstractApiClient extends AbstractCoreApiClient implements ApiCli
         ];
 
         if ($parameters) {
-            $options['query'] = $parameters->getContainer();
+            $query = http_build_query($parameters->getContainer(), null, '&', PHP_QUERY_RFC3986);
+            $options['query'] = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $query);
         }
 
         $response = $this->makeRequest('GET', 'videos', $options);
@@ -128,7 +129,8 @@ abstract class AbstractApiClient extends AbstractCoreApiClient implements ApiCli
         ];
 
         if ($parameters) {
-            $options['query'] = $parameters->getContainer();
+            $query = http_build_query($parameters->getContainer(), null, '&', PHP_QUERY_RFC3986);
+            $options['query'] = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $query);
         }
 
         $response = $this->makeRequest('GET', 'videos', $options);


### PR DESCRIPTION
When generating the query string, guzzle transforms the array parameters with indexes and this is not supported by vmpro endpoint.
For that we generate the query string in the client and pass it to guzzle client as string