### PR TITLE
[CT-2368] BE Get localized metadata for single video

### DIFF
--- a/lib/Entity/VideoRequestParameters.php
+++ b/lib/Entity/VideoRequestParameters.php
@@ -12,6 +12,7 @@ use MovingImage\Client\VMPro\Util\AccessorTrait;
  * @method string                 getCustomMetadataField()
  * @method VideoRequestParameters setCustomMetadataField(string $customMetadataField)
  * @method VideosRequestParameters setMetadataSetId(int $metadataSetId)
+ * @method VideosRequestParameters setIncludeChannelAssignments(bool $includeChannels)
  * @method bool                   isIncludeKeywords()
  * @method VideoRequestParameters setIncludeKeywords(bool $includeKeywords)
  * @method int                    getRelatedVideosChannelId()

--- a/lib/Entity/VideoRequestParameters.php
+++ b/lib/Entity/VideoRequestParameters.php
@@ -11,6 +11,7 @@ use MovingImage\Client\VMPro\Util\AccessorTrait;
  * @method VideoRequestParameters setIncludeCustomMetadata(bool $includeCustomMetadata)
  * @method string                 getCustomMetadataField()
  * @method VideoRequestParameters setCustomMetadataField(string $customMetadataField)
+ * @method VideosRequestParameters setMetadataSetId(int $metadataSetId)
  * @method bool                   isIncludeKeywords()
  * @method VideoRequestParameters setIncludeKeywords(bool $includeKeywords)
  * @method int                    getRelatedVideosChannelId()


### PR DESCRIPTION
Closes - [CT-2368]

Changes:
- Added `@method` annotation for `setMetadataSetId()` method
- Added `@method` annotation for `setIncludeChannelAssignments()` method
